### PR TITLE
Improvements to connect request & disconnect #1

### DIFF
--- a/LogicalPacket.Demo/NetEventListener.cs
+++ b/LogicalPacket.Demo/NetEventListener.cs
@@ -19,9 +19,9 @@ public class NetEventListener : INetEventListener
         Console.WriteLine($"Peer {peer} connected");
     }
 
-    public void OnPeerDisconnected(Peer peer)
+    public void OnPeerDisconnected(Peer peer, DisconnectInfo info)
     {
-        Console.WriteLine($"Peer {peer} disconnected");
+        Console.WriteLine($"Peer {peer} disconnected with reason: {info.Reason}");
     }
 
     public void OnPacketReceived(Peer peer, PacketReader reader, DeliveryMethod deliveryMethod)

--- a/LogicalPacket.Demo/NetEventListener.cs
+++ b/LogicalPacket.Demo/NetEventListener.cs
@@ -9,21 +9,10 @@ public class NetEventListener : INetEventListener
 {
     private readonly MemoryPool<byte> _bufferPool = MemoryPool<byte>.Shared;
 
-    public void OnPacketReceived(Peer peer, PacketReader reader, DeliveryMethod deliveryMethod)
+    public void OnConnectionRequest(ConnectionRequest request)
     {
-        Console.WriteLine($"Packet received from {peer} with method {deliveryMethod}");
-
-        using var buffer = _bufferPool.Rent(1024);
-        var writer = new PacketWriter(buffer.Memory.Span);
-        writer.WriteString("From server yo");
-        peer.Send(writer.Data, DeliveryMethod.Unreliable);
+        request.AcceptIfKey("MyKey");
     }
-
-    public void OnError(IPEndPoint endPoint, SocketError error)
-    {
-        throw new NotImplementedException();
-    }
-
 
     public void OnPeerConnected(Peer peer)
     {
@@ -33,5 +22,20 @@ public class NetEventListener : INetEventListener
     public void OnPeerDisconnected(Peer peer)
     {
         Console.WriteLine($"Peer {peer} disconnected");
+    }
+
+    public void OnPacketReceived(Peer peer, PacketReader reader, DeliveryMethod deliveryMethod)
+    {
+        Console.WriteLine($"Packet received from {peer} with method {deliveryMethod}");
+
+        using var buffer = _bufferPool.Rent(1024);
+        var writer = new PacketWriter(buffer.Memory.Span);
+        writer.WriteString("Hello from server");
+        peer.Send(writer.Data, DeliveryMethod.Unreliable);
+    }
+
+    public void OnError(IPEndPoint endPoint, SocketError error)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/LogicalPacket/Core/ConnectionRequest.cs
+++ b/LogicalPacket/Core/ConnectionRequest.cs
@@ -1,0 +1,44 @@
+using System.Net;
+
+namespace LogicalPacket.Core;
+
+public class ConnectionRequest
+{
+    private readonly Server _server;
+    private readonly IPEndPoint _remoteEndPoint;
+    private readonly Packet _packet;
+
+    internal ConnectionRequest(Server server, IPEndPoint remoteEndPoint, Packet packet)
+    {
+        _server = server;
+        _remoteEndPoint = remoteEndPoint;
+        _packet = packet;
+    }
+
+    public void Accept()
+    {
+        _server.AcceptConnection(_remoteEndPoint);
+    }
+
+    public void AcceptIfKey(string key)
+    {
+        var reader = new PacketReader(_packet.Payload.Span);
+
+        try
+        {
+            if (reader.ReadString() == key)
+                _server.AcceptConnection(_remoteEndPoint);
+            else
+                _server.RejectConnection(_remoteEndPoint);
+        }
+        catch
+        {
+            Console.WriteLine("Invalid incoming data");
+        }
+    }
+
+    public void Reject()
+    {
+        _server.RejectConnection(_remoteEndPoint);
+    }
+}

--- a/LogicalPacket/Core/INetEventListener.cs
+++ b/LogicalPacket/Core/INetEventListener.cs
@@ -5,6 +5,7 @@ namespace LogicalPacket.Core;
 
 public interface INetEventListener
 {
+    void OnConnectionRequest(ConnectionRequest request);
     void OnPeerConnected(Peer peer);
     void OnPeerDisconnected(Peer peer);
     void OnPacketReceived(Peer peer, PacketReader reader, DeliveryMethod deliveryMethod);

--- a/LogicalPacket/Core/INetEventListener.cs
+++ b/LogicalPacket/Core/INetEventListener.cs
@@ -7,7 +7,19 @@ public interface INetEventListener
 {
     void OnConnectionRequest(ConnectionRequest request);
     void OnPeerConnected(Peer peer);
-    void OnPeerDisconnected(Peer peer);
+    void OnPeerDisconnected(Peer peer, DisconnectInfo info);
     void OnPacketReceived(Peer peer, PacketReader reader, DeliveryMethod deliveryMethod);
     void OnError(IPEndPoint endPoint, SocketError error);
 }
+
+public enum DisconnectReason
+{
+    Unknown,
+    ServerShutdown,
+    Timeout,
+    ConnectionLost,
+    ConnectionRefused,
+    RemoteClose
+}
+
+public record struct DisconnectInfo(DisconnectReason Reason, SocketError? SocketError);

--- a/LogicalPacket/Core/NetEvent.cs
+++ b/LogicalPacket/Core/NetEvent.cs
@@ -6,7 +6,7 @@ internal abstract record NetEvent(Peer Peer);
 
 internal sealed record ConnectEvent(Peer Peer) : NetEvent(Peer);
 
-internal sealed record DisconnectEvent(Peer Peer) : NetEvent(Peer);
+internal sealed record DisconnectEvent(Peer Peer, DisconnectInfo Info) : NetEvent(Peer);
 
 internal sealed record ReceiveEvent(Peer Peer, Packet Packet, DeliveryMethod DeliveryMethod) : NetEvent(Peer);
 
@@ -19,9 +19,9 @@ internal static class NetEvents
         return new ConnectEvent(peer);
     }
 
-    public static DisconnectEvent Disconnect(Peer peer)
+    public static DisconnectEvent Disconnect(Peer peer, DisconnectInfo info)
     {
-        return new DisconnectEvent(peer);
+        return new DisconnectEvent(peer, info);
     }
 
     public static ReceiveEvent Receive(Peer peer, Packet packet, DeliveryMethod deliveryMethod)

--- a/LogicalPacket/Core/Packet.cs
+++ b/LogicalPacket/Core/Packet.cs
@@ -56,8 +56,9 @@ internal readonly struct Packet : IDisposable
 
 public enum PacketType : byte
 {
-    Connect,
+    ConnectRequest,
     ConnectAccept,
+    ConnectReject,
     Disconnect,
     Unreliable,
     Ping,

--- a/LogicalPacket/Core/Packet.cs
+++ b/LogicalPacket/Core/Packet.cs
@@ -60,6 +60,7 @@ public enum PacketType : byte
     ConnectAccept,
     ConnectReject,
     Disconnect,
+    Shutdown,
     Unreliable,
     Ping,
     Pong

--- a/LogicalPacket/Core/Peer.cs
+++ b/LogicalPacket/Core/Peer.cs
@@ -57,12 +57,12 @@ public sealed class Peer : IPEndPoint
         _sendTask = Task.Run(() => _unreliableChannel.ProcessAsync(_cts.Token), _cts.Token);
     }
 
-    internal async Task DisconnectAsync()
+    internal void Disconnect()
     {
-        if (_cts != null) await _cts.CancelAsync();
-        _unreliableChannel.Complete();
-        if (_sendTask != null) await _sendTask;
+        _cts?.Cancel();
         _cts?.Dispose();
+        _cts = null;
+        _unreliableChannel.Complete();
     }
 
     internal void ProcessPacket(Packet packet)

--- a/LogicalPacket/Server.cs
+++ b/LogicalPacket/Server.cs
@@ -171,7 +171,7 @@ public sealed class Server : IDisposable
 
     private void HandlePacket(Packet packet, IPEndPoint remoteEndPoint)
     {
-        var peeerFound = _peers.TryGetValue(remoteEndPoint, out var peer);
+        var peerFound = _peers.TryGetValue(remoteEndPoint, out var peer);
 
         switch (packet.Type)
         {
@@ -182,7 +182,7 @@ public sealed class Server : IDisposable
             case PacketType.Disconnect:
                 break;
             default:
-                if (peeerFound)
+                if (peerFound)
                     peer!.ProcessPacket(packet);
                 else
                     packet.Dispose();


### PR DESCRIPTION
Implements ability for end-users to accept/reject peers using the event listener. Peers can also send Disconnection packets to shutdown gracefully. More improvements to come.